### PR TITLE
[IMP][l10n_it_account_stamp] Add 'amount_untaxed' to '_onchange_tax_l…

### DIFF
--- a/l10n_it_account_stamp/models/invoice.py
+++ b/l10n_it_account_stamp/models/invoice.py
@@ -29,7 +29,7 @@ class AccountInvoice(models.Model):
         else:
             return False
 
-    @api.onchange('tax_line_ids')
+    @api.onchange('amount_untaxed', 'tax_line_ids')
     def _onchange_tax_line_ids(self):
         if self.auto_compute_stamp:
             self.tax_stamp = self.is_tax_stamp_applicable()


### PR DESCRIPTION
…ine_ids' onchange decorator

Aggiunta di `amount_untaxed` sul decoratore della onchange.
Questo perché attualmente il decoratore tiene conto solo del numero di righe della fattura, ma se una di queste righe viene modificata aumentando o diminuendo l'imponibile, non scatta il ricalcolo.
L'aggiunta del decoratore permette il ricalcolo se viene modificato l'imponibile di una riga e, di conseguenza, quello dell'intera fattura.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
